### PR TITLE
ServiceHub services should match VS dependency versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ flowchart TD
     vs_main_dependencies --> vs_main_dependencies_automated
     public_package_updates_only
     xunitv2
+    servicehub_service --> vs_main_dependencies
     servicehub_service --> dotnet_packages_below
     dotnet_packages_LTS --> dotnet_packages_below
 ```

--- a/servicehub_service.json
+++ b/servicehub_service.json
@@ -1,6 +1,9 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
 	"description": "Limits NuGet package updates offered to those appropriate for ServiceHub services.",
-	"extends": ["github>microsoft/vs-renovate-presets:dotnet_packages_below(9)"],
+	"extends": [
+		"github>microsoft/vs-renovate-presets:vs_main_dependencies",
+		"github>microsoft/vs-renovate-presets:dotnet_packages_below(9)"
+	],
 	"packageRules": []
 }


### PR DESCRIPTION
ServiceHub services have many .NET assemblies 'in box' that they can and should use rather than bundling their own dependencies. The versions of these dependencies always match what VS is already shipping.